### PR TITLE
ITE-2864 ITE-2683 added admin acl and accesslog

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -101,3 +101,20 @@ default['openldap']['syncrepl_consumer_config']['credentials'] = nil
 
 # The maximum number of entries that is returned for a search operation
 default['openldap']['server_config_hash']['sizelimit'] = 500
+
+# The iam default block is to setup custom admin acls. 
+default['openldap']['iam'] = [
+  {
+    'what': '*',
+    'type': [
+      {
+        'who': 'self',
+        'access': 'write',
+      },
+      {
+        'who': '*',
+        'access': 'read',
+      },
+    ],
+  },
+]

--- a/templates/default/slapd.conf.erb
+++ b/templates/default/slapd.conf.erb
@@ -55,6 +55,16 @@ backend		<%= node['openldap']['database'] %>
 #####
 # Database
 #####
+
+# accesslog configuration
+<% if node['openldap']['accesslog_enabled'] || node['openldap']['accesslog_enabled']-%>
+database       <%= node['openldap']['database'] %>
+suffix         "<%= node['openldap']['accesslog_suffix'] %>"
+directory      <%= node['openldap']['accesslog_directory'] %>
+index          <%= node['openldap']['accesslog_index'] %>
+<% end -%>
+
+# DIT configuration
 database        <%= node['openldap']['database'] %>
 suffix          "<%= node['openldap']['basedn'] %>"
 rootdn          "cn=<%= node['openldap']['cn'] %>,<%= node['openldap']['basedn'] %>"
@@ -114,14 +124,14 @@ syncrepl rid=<%= node['openldap']['slapd_rid'] %>
 # The userPassword by default can be changed by the entry owning it if they are
 # authenticated. Others should not be able to see it, except the admin entry
 # below. These access lines apply to database #1 only.
-access to attrs=<%= node['openldap']['user_attrs'] %>
-        by group.exact="cn=<%= node['openldap']['admin_cn'] %>,<%= node['openldap']['basedn'] %>" write
-<% if node['openldap']['slapd_type'] == "provider" -%>
-        by dn="<%= node['openldap']['syncrepl_cn'] %>,<%= node['openldap']['basedn'] %>" read
-<% end -%>
-        by anonymous auth
-        by self write
-        by * none
+# access to attrs=<%= node['openldap']['user_attrs'] %>
+#         by group.exact="cn=<%= node['openldap']['admin_cn'] %>,<%= node['openldap']['basedn'] %>" write
+# <% if node['openldap']['slapd_type'] == "provider" -%>
+#         by dn="<%= node['openldap']['syncrepl_cn'] %>,<%= node['openldap']['basedn'] %>" read
+# <% end -%>
+#         by anonymous auth
+#         by self write
+#         by * none
 
 # Ensure read access to the base for things like supportedSASLMechanisms.
 # Without this you may have problems with SASL not knowing what mechanisms are
@@ -131,9 +141,17 @@ access to attrs=<%= node['openldap']['user_attrs'] %>
 access to dn.base="" by * read
 
 # The admin dn has full write access, everyone else can read everything.
-access to *
-        by group.exact="cn=<%= node['openldap']['admin_cn'] %>,<%= node['openldap']['basedn'] %>" write
-<% if node['openldap']['slapd_type'] == "provider" -%>
-        by dn="<%= node['openldap']['syncrepl_cn'] %>,<%= node['openldap']['basedn'] %>" read
-<% end -%>
-        by * read
+# access to *
+#         by group.exact="cn=<%= node['openldap']['admin_cn'] %>,<%= node['openldap']['basedn'] %>" write
+# <% if node['openldap']['slapd_type'] == "provider" -%>
+#         by dn="<%= node['openldap']['syncrepl_cn'] %>,<%= node['openldap']['basedn'] %>" read
+# <% end -%>
+#         by * read
+
+# added method to add custom admin acls. 
+<% node['openldap']['iam'].uniq.each do |acl| %>
+access to <%= acl['what'] %>
+<% acl['type'].uniq.each do |type| %>
+        by <%= type['who'] %> <%= type['access'] %>
+<% end %>
+<% end %>


### PR DESCRIPTION
<!-- Need support on our inclusive code practices? Visit http://go/inclusivecode -->

## Description

* Needed a method to add custom iam acls.  The default method only gave you the default and we need a method to add our own.
* Accesslog setup requires database section as well as an overlay section, added to the template with an enable option to add it to the slapd configuration.  

## Context / Why are we making this change?

We have custom admin acls' we need to implement so we've modified the base template to accept an attribute in json format to the code to iterate through and write it out to the slapd.conf file. 

Commented out the default with the exception of the `access to dn.base="" by * read` as this is also required and not duplicated with our the new functionality 

Accesslog requires the database to be listed with databases. 

## Testing and QA Plan

> How has this work been tested or QA'd?

## Impact

> What are the implications of these changes? Are there any cross-cutting concerns to keep in mind?
