### PR TITLE
ITE-2684 adding accesslogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+Accesslog Database and Overlay configuration.
+
+- added accesslog database and overlay stanza into slapd.conf.erb template.
+
+Added additional attributes.
+
+- `default['openldap']['accesslog']['enabled']` to enable additional accesslog configuration.
+- `default['openldap']['accesslog']['logdb']` specifies the suffix of the database.
+- `default['openldap']['accesslog']['directory']` specifes the directory to store the accesslog database.
+- `default['openldap']['accesslog']['index']` specifies the database index.
+- `default['openldap']['accesslog']['logops']` specifies which type of operations to log.
+- `default['openldap']['accesslog']['logbase']` specifies a set of operations that will only be logged if they occur under a specific subtree of the database.
+- `default['openldap']['accesslog']['logold']` specifies a filter for matching against Deleted and Modified entries.
+- `default['openldap']['accesslog']['logoldattr']` specify a list of attributes whose old contents are always logged in Modify and ModRDN requests that match any of the filters configured in logold.
+- `default['openldap']['accesslog']['logpurge']` specify the maximum age for log entries to be retained in the database
+- `default['openldap']['accesslog']['logsuccess']` if set to TRUE then log records will only be generated for successful requests.
+
 ## 6.1.4 - *2024-07-15*
 
 Standardise files with files in sous-chefs/repo-management

--- a/README.md
+++ b/README.md
@@ -100,6 +100,25 @@ pair in the `openldap['syncrepl_*_config]` (See the OpenLDAP Adminstrator Guide)
 - `openldap['syncrepl_consumer_config']['starttls']` - `yes | no (default)`
 - `openldap['syncrepl_consumer_config']['credentials']` - defaults to `openldap['slapd_replpw']`
 
+### Accesslog
+
+Enabling Accesslog will require to include the accesslog.la module.
+
+- add `node.default['openldap']['modules'] << 'accesslog'
+
+Attributes related to Accesslog database and overlay configuration.
+
+`openldap['accesslog']['enabled']` - add accesslog configuration true | false (default)
+`openldap['accesslog']['logdb']` -  defaults to `"cn=accesslog"`
+`openldap['accesslog']['directory']` - defaults to `'/var/log/'`
+`openldap['accesslog']['index']` - defaults to `'reqStart,reqEnd,reqResult eq'`
+`openldap['accesslog']['logops']` - defaults to `'writes'`
+`openldap['accesslog']['logbase']` - not set by default
+`openldap['accesslog']['logold']` - defaults to '(objectclass=*)'
+`openldap['accesslog']['logoldattr']` - defaults to nil
+`openldap['accesslog']['logpurge']` - defaults to '8+00:00 1+00:00' purges after 8 and checks daily.
+`openldap['accesslog']['logsuccess']` - defaults to false
+
 ## Recipes
 
 ### default

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -101,3 +101,15 @@ default['openldap']['syncrepl_consumer_config']['credentials'] = nil
 
 # The maximum number of entries that is returned for a search operation
 default['openldap']['server_config_hash']['sizelimit'] = 500
+
+# accesslog db and overlay parameters
+default['openldap']['accesslog']['enabled'] = false
+default['openldap']['accesslog']['logdb'] = '"cn=accesslog"'
+default['openldap']['accesslog']['directory'] = '/var/lib/ldap/accesslog'
+default['openldap']['accesslog']['index'] = 'reqStart,reqEnd,reqResult eq'
+default['openldap']['accesslog']['logops'] = 'writes'
+default['openldap']['accesslog']['logbase'] = nil
+default['openldap']['accesslog']['logold'] = '(objectclass=*)'
+default['openldap']['accesslog']['logoldattr'] = nil
+default['openldap']['accesslog']['logpurge'] = '8+00:00 1+00:00'
+default['openldap']['accesslog']['logsuccess'] = false

--- a/templates/default/slapd.conf.erb
+++ b/templates/default/slapd.conf.erb
@@ -55,6 +55,14 @@ backend		<%= node['openldap']['database'] %>
 #####
 # Database
 #####
+<% if node['openldap']['accesslog']['enabled'] == true -%>
+# accesslog configuration
+database       <%= node['openldap']['database'] %>
+suffix         "<%= node['openldap']['accesslog']['logdb'] %>"
+directory      <%= node['openldap']['accesslog']['directory'] %>
+index          <%= node['openldap']['accesslog']['index'] %>
+<% end -%>
+
 database        <%= node['openldap']['database'] %>
 suffix          "<%= node['openldap']['basedn'] %>"
 rootdn          "cn=<%= node['openldap']['cn'] %>,<%= node['openldap']['basedn'] %>"
@@ -137,3 +145,27 @@ access to *
         by dn="<%= node['openldap']['syncrepl_cn'] %>,<%= node['openldap']['basedn'] %>" read
 <% end -%>
         by * read
+
+<% if node['openldap']['accesslog']['enabled'] == true -%>
+# enable the accesslog overlay so that we can audit LDAP updates
+overlay accesslog
+logdb "<%= node['openldap']['accesslog']['logdb'] %>" 
+# log add, delete, modify, modrdn operations
+logops <%= node['openldap']['accesslog']['logops'] %>
+# logbase <operations> <baseDN> are delimited by a | character
+<% if node['openldap']['accesslog']['logbase'] -%>
+logbase <%= node['openldap']['accesslog']['logbase'] %>
+<% end -%>
+# log the entry's previous info if it's being deleted or modified
+logold <%= node['openldap']['accesslog']['logold'] %>
+# logoldattr <attr> 
+<% if node['openldap']['accesslog']['logoldattr'] -%>
+logoldattr <%= node['openldap']['accesslog']['logoldattr'] %>
+<% end -%>
+# purge entries after 8 days; check daily for old entries (8+00:00 1+00:00)
+logpurge <%= node['openldap']['accesslog']['logpurge'] %>
+<% if node['openldap']['accesslog']['logsuccess'] -%>
+# logsuccess TRUE | FALSE (default false)
+logsuccess <%= node['openldap']['accesslog']['logsuccess'] %>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
<!-- Need support on our inclusive code practices? Visit http://go/inclusivecode -->

## Description

Adding accesslog functionality 

## Context / Why are we making this change?

We currently have accesslog and will need to continue having this function in our new openldap infrastructure.  We are unable to get the base `sous-chef openldap` cookbook load the accesslog database and overlay properly for it to function so added that functionality to the forked cookbook. 

## Testing and QA Plan

> How has this work been tested or QA'd?

## Impact

> What are the implications of these changes? Are there any cross-cutting concerns to keep in mind?
